### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-sg.hackandtell.org


### PR DESCRIPTION
Removing CNAME from here as the new site source is at
https://github.com/hackandtell-sg/sg.hackandtell.org and GitHub does not allow
having the same CNAME in multiple repositories.